### PR TITLE
remove tests from publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,6 @@ on:
 jobs:
   build:
     name: Build distribution
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
we need to remove tests from the publish to pypi pipeline since the worker node is tiny and weak and it's been stuck for more than 20 minutes. 

<img width="161" height="63" alt="image" src="https://github.com/user-attachments/assets/01b3a65b-7f16-47ae-99ad-399b9f1a7f17" />
